### PR TITLE
Removing reference to qt5-default for Raspberry Pi

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -207,7 +207,7 @@ sudo apt install \
 	libqt5webkit5-dev libsqlite3-dev libssh2-1-dev libssl-dev libtool \
 	libusb-1.0-0-dev libxml2-dev libxslt1-dev libzip-dev make pkg-config \
 	qml-module-qtlocation qml-module-qtpositioning qml-module-qtquick2 \
-	qt5-default qt5-qmake qtchooser qtconnectivity5-dev qtdeclarative5-dev \
+	qt5-qmake qtchooser qtconnectivity5-dev qtdeclarative5-dev \
 	qtdeclarative5-private-dev qtlocation5-dev qtpositioning5-dev \
 	qtscript5-dev qttools5-dev qttools5-dev-tools libmtp-dev
 


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Removing reference to qt5-default under Raspberry Pi installation section

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1), removed qt5-default package from the required package list

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Dirk reported in a recent email thread that a recent change in packaging has removed the need for it.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
